### PR TITLE
Adding downstream accuracy CCL params

### DIFF
--- a/augur/generate.py
+++ b/augur/generate.py
@@ -88,6 +88,30 @@ def generate_sacc_and_stats(config):
     if cosmo_cfg.get('extra_parameters') is None:
         cosmo_cfg['extra_parameters'] = dict()
 
+    if 'ccl_accuracy' in config.keys():
+        # Pass along spline control parameters
+        if 'spline_params' in config['ccl_accuracy'].keys():
+            for key in config['ccl_accuracy']['spline_params'].keys():
+                try:
+                    type_here = type(ccl.spline_params[key])
+                    value = config['ccl_accuracy']['spline_params'][key]
+                    ccl.spline_params[key] = type_here(value)
+                except KeyError:
+                    print(f'The selected spline keyword `{key}` is not recognized.')
+                except ValueError:
+                    print(f'The selected value `{value}` could not be casted to `{type_here}`.')
+        # Pass along GSL control parameters
+        if 'gsl_params' in config['ccl_accuracy'].keys():
+            for key in config['ccl_accuracy']['gsl_params'].keys():
+                try:
+                    type_here = type(ccl.gsl_params[key])
+                    value = config['ccl_accuracy']['gsl_params'][key]
+                    ccl.gsl_params[key] = type_here(value)
+                except KeyError:
+                    print(f'The selected GSL keyword `{key}` is not recognized.')
+                except ValueError:
+                    print(f'The selected value `{value}` could not be casted to `{type_here}`.')
+
     try:
         cosmo = ccl.Cosmology(**cosmo_cfg)
     except (KeyError, TypeError, ValueError) as e:

--- a/examples/config_test.yml
+++ b/examples/config_test.yml
@@ -12,6 +12,12 @@ cosmo:
     # transfer_function : 'eisenstein_hu'  # If you want to specify the transfer function you can do so here
     # If the transfer function is not specified, it defaults to using CAMB
 
+ccl_accuracy:  # Example of a couple of parameters to modify.
+    spline_params:  # You can change here any pyccl.spline_params
+        K_MAX_SPLINE : 100
+    gsl_params:  # You can change here any pyccl.gsl_params
+        INTEGRATION_EPSREL: 1e-6
+
 sources:  # Sources
     nbins : 5
     ndens : 10  # in arcmin^-2 (it should be a scalar with the total number density or a list with each bin's)


### PR DESCRIPTION
This PR addresses #56, and adds the ability to pass along CCL accuracy parameters through `augur`. I still have to check whether these are passed downstream to firecrown (I suspect so, but not 100% sure). 