### PR TITLE
Gaussian Priors and Omega_m-S8 Transformation

### DIFF
--- a/augur/analyze.py
+++ b/augur/analyze.py
@@ -148,7 +148,6 @@ class Analyze(object):
                 _val = self.config['gaussian_priors'][var]
                 self.gpriors.append(_val)
 
-        print(self.gprior_pars, self.gpriors, self.var_pars)
     def f(self, x, labels, pars_fid, sys_fid, donorm=False):
         """
         Auxiliary Function that returns a theory vector evaluated at x.
@@ -233,7 +232,6 @@ class Analyze(object):
         if (self.derivatives is None) or (force):
             if '5pt_stencil' in method:
                 if self.norm_step:
-                    print(self.x)
                     x_here = (self.x - np.array(self.par_bounds[:, 0]).astype(np.float64)) \
                         * 1/self.norm
                 else:
@@ -248,7 +246,6 @@ class Analyze(object):
                 else:
                     ndkwargs = {}
                 if self.norm_step:
-                    print(self.x)
                     x_here = (self.x - np.array(self.par_bounds[:, 0]).astype(np.float64)) \
                         * 1/self.norm
                 else:
@@ -268,7 +265,6 @@ class Analyze(object):
         else:
             return self.derivatives
 
-
     def add_gaussian_priors(self, save_txt=True):
         """
         Auxiliary function to add user-specified Gaussian priors to parameters.
@@ -284,8 +280,6 @@ class Analyze(object):
 
             indices = []
             for gvar in self.gprior_pars:
-                print(gvar)
-                print(np.where(np.array(self.var_pars) == gvar))
                 if gvar in self.var_pars:
                     indices.append(np.where(np.array(self.var_pars) == gvar)[0][0])
                 else:
@@ -296,16 +290,14 @@ class Analyze(object):
             gprior_only = np.zeros((len(self.Fij), len(self.Fij)))
             for i in range(len(self.gpriors)):
                 j = indices[i]
-                print(j, i, self.gpriors[i])
-                self.Fij_with_gprior[j][j]+=1.0/self.gpriors[i]**2
-                gprior_only[j][j]+=1.0/self.gpriors[i]**2
-            
+                self.Fij_with_gprior[j][j] += 1.0/self.gpriors[i]**2
+                gprior_only[j][j] += 1.0/self.gpriors[i]**2
+
             if save_txt:
                 np.savetxt(self.config['output']+".priors_only", gprior_only)
                 np.savetxt(self.config['output']+".with_priors", self.Fij_with_gprior)
 
         return self.Fij_with_gprior
-
 
     def get_fisher_matrix(self, method='5pt_stencil', save_txt=True):
         # Compute Fisher matrix assuming Gaussian likelihood (around self.x)
@@ -313,7 +305,7 @@ class Analyze(object):
             self.get_derivatives(method=method)
         if self.Fij is None:
             self.Fij = np.einsum('il, lm, jm', self.derivatives, self.lk.inv_cov, self.derivatives)
-            
+
             if save_txt:
                 np.savetxt(self.config['output'], self.Fij)
                 tab_out = Table(self.x.T, names=self.var_pars)
@@ -368,9 +360,11 @@ class Analyze(object):
                     if use_fid:
                         self.biased_cls = biased_cls['dv_sys'] - self.data_fid
                     else:
-
-                        self.biased_cls = biased_cls['dv_sys'] - self.f(self.x, self.var_pars, self.pars_fid,
-                                                   self.req_params, donorm=False)
+                        self.biased_cls = biased_cls['dv_sys'] - self.f(self.x,
+                                                                        self.var_pars,
+                                                                        self.pars_fid,
+                                                                        self.req_params,
+                                                                        donorm=False)
             # If there's no biased data vector, calculate it
             if _calculate_biased_cls:
                 _x_here = []
@@ -395,11 +389,13 @@ class Analyze(object):
 
                 if use_fid:
                     self.biased_cls = self.f(_x_here, _labels_here, _pars_here, _sys_here,
-                                         donorm=False)- self.data_fid
+                                             donorm=False) - self.data_fid
                 else:
                     self.biased_cls = self.f(_x_here, _labels_here, _pars_here, _sys_here,
-                                         donorm=False) - self.f(self.x, self.var_pars, self.pars_fid,
-                                                   self.req_params, donorm=False)
+                                             donorm=False) - self.f(self.x, self.var_pars,
+                                                                    self.pars_fid,
+                                                                    self.req_params,
+                                                                    donorm=False)
             Bj = np.einsum('l, lm, jm', self.biased_cls, self.lk.inv_cov, self.derivatives)
             bi = np.einsum('ij, j', np.linalg.inv(self.Fij), Bj)
             self.bi = bi

--- a/augur/postprocess.py
+++ b/augur/postprocess.py
@@ -54,9 +54,9 @@ def postprocess(config):
     ls = pconfig["linestyle"] if "linestyle" in pconfig.keys() else "-"
     edgecolors = pconfig["linecolor"] if "linecolor" in pconfig.keys() else "k"
     facecolors = pconfig["facecolor"] if "facecolor" in pconfig.keys() else "none"
-    CL = pconfig["CL"] if "CL" in pconfig.keys() else [0.68,]
+    CL = pconfig["CL"] if "CL" in pconfig.keys() else [0.68, ]
     if not isinstance(CL, list):
-        CL = [CL,]
+        CL = [CL, ]
     f, ax = plt.subplots(npars, npars, figsize=(xsize, ysize))
 
     try:

--- a/augur/utils/theory_utils.py
+++ b/augur/utils/theory_utils.py
@@ -76,7 +76,10 @@ def compute_new_theory_vector(lk, tools, _sys_pars, _pars, cf=None, return_all=F
                 dict_all.pop(key)
         if cf is None:
             cf = CCLFactory(**extra_dict)
-            tools = firecrown.modeling_tools.ModelingTools(ccl_factory=cf)
+            if tools.pt_calculator is not None:
+                tools = firecrown.modeling_tools.ModelingTools(pt_calculator=tools.get_pt_calculator(), ccl_factory=cf)
+            else:
+                tools = firecrown.modeling_tools.ModelingTools(ccl_factory=cf)
             tools.reset()
         pmap = ParamsMap(dict_all)
         cf.update(pmap)

--- a/augur/utils/theory_utils.py
+++ b/augur/utils/theory_utils.py
@@ -77,7 +77,8 @@ def compute_new_theory_vector(lk, tools, _sys_pars, _pars, cf=None, return_all=F
         if cf is None:
             cf = CCLFactory(**extra_dict)
             if tools.pt_calculator is not None:
-                tools = firecrown.modeling_tools.ModelingTools(pt_calculator=tools.get_pt_calculator(), ccl_factory=cf)
+                ptc = tools.get_pt_calculator()
+                tools = firecrown.modeling_tools.ModelingTools(pt_calculator=ptc, ccl_factory=cf)
             else:
                 tools = firecrown.modeling_tools.ModelingTools(ccl_factory=cf)
             tools.reset()

--- a/augur/utils/theory_utils.py
+++ b/augur/utils/theory_utils.py
@@ -75,7 +75,7 @@ def compute_new_theory_vector(lk, tools, _sys_pars, _pars, cf=None, return_all=F
             if (dict_all[key] is None) or (dict_all[key] == 'None'):
                 dict_all.pop(key)
         if cf is None:
-            cf = CCLFactory(**extra_dict)
+            cf = CCLFactory(**extra_dict, require_nonlinear_pk=True, use_camb_hm_sampling=True)
             if tools.pt_calculator is not None:
                 ptc = tools.get_pt_calculator()
                 tools = firecrown.modeling_tools.ModelingTools(pt_calculator=ptc, ccl_factory=cf)


### PR DESCRIPTION
Augur up to this point has been shown to reproduce other Fisher contours nicely. This PR aims to expand the use Augur use cases to allow using Gaussian priors on the Fisher matrix. The user will specify the prior width through a separate header in the input yaml configuration file. Further, this PR also aims to implement a Jacobian Transformation (@shankarshana16) of variables to obtain Omega_m-S8 Fisher contours from Omega_c-sigma_8 input parameters. 

The PR depends on using Firecrown 1.11.0, which allows T_agn in HMCode/CAMB to be a free variable. Additional refactoring may be needed to implement this change in the `generate.py` script and to properly read the required parameters from Firecrown modeling tools and likelihood. 