### PR TITLE
Adjust to new Firecrown module structure for v1.15

### DIFF
--- a/augur/generate.py
+++ b/augur/generate.py
@@ -17,7 +17,11 @@ from augur.utils.theory_utils import compute_new_theory_vector
 from packaging.version import Version
 import firecrown
 
-if Version(firecrown.__version__) >= Version('1.8.0a'):
+if Version(firecrown.__version__) >= Version('1.15.a'):
+    import firecrown.likelihood.weak_lensing as wl
+    import firecrown.likelihood.number_counts as nc
+    from firecrown.likelihood import TwoPoint, ConstGaussian
+elif Version(firecrown.__version__) >= Version('1.8.0a'):
     import firecrown.likelihood.weak_lensing as wl
     import firecrown.likelihood.number_counts as nc
     from firecrown.likelihood.two_point import TwoPoint


### PR DESCRIPTION
This PR adjusts Augur to deal with the new Firecrown package organization, introduced in release 1.15.0 of Firecrown.
It is intended to be backwards compatible with older releases of Firecrown.