### PR TITLE
fix for interface with TJPCov to allow computation of src, lens, or both

### DIFF
--- a/augur/utils/cov_utils.py
+++ b/augur/utils/cov_utils.py
@@ -37,15 +37,16 @@ def get_noise_power(config, S, tracer_name, return_ndens=False):
     for tr in S.tracers:
         trobj = S.get_tracer(tr)
         nz_all[tr[:-1]].append(trobj.nz)  # This assumes 10 or less bins
-    nz_all['src'] = np.array(nz_all['src'])
-    nz_all['lens'] = np.array(nz_all['lens'])
     norm = dict()
-    norm['src'] = np.sum(nz_all['src'], axis=1)/np.sum(nz_all['src'])
-    norm['lens'] = np.sum(nz_all['lens'], axis=1)/np.sum(nz_all['lens'])
     if 'src' in tracer_name:
+        nz_all['src'] = np.array(nz_all['src'])
+        norm['src'] = np.sum(nz_all['src'], axis=1)/np.sum(nz_all['src'])
+
         ndens = config['sources']['ndens']
         ndens *= norm['src'][int(tracer_name[-1])]
     elif 'lens' in tracer_name:
+        nz_all['lens'] = np.array(nz_all['lens'])
+        norm['lens'] = np.sum(nz_all['lens'], axis=1)/np.sum(nz_all['lens'])
         ndens = config['lenses']['ndens']
         ndens *= norm['lens'][int(tracer_name[-1])]
     nbar = ndens * (180 * 60 / np.pi) ** 2  # per steradian


### PR DESCRIPTION
Small bug fix putting relevant 'src' and 'lens' contributions after tags are detected, allowing for single 2pt computations of the Gaussian covariance with TJPCov