### PR TITLE
Propagate mass_split from Augur config into CCLFactory

### DIFF
--- a/augur/utils/firecrown_interface.py
+++ b/augur/utils/firecrown_interface.py
@@ -131,6 +131,7 @@ def _create_ccl_factory(config):
             creation_mode=CCLCreationMode.MU_SIGMA_ISITGR,
             require_nonlinear_pk=require_nl,
             amplitude_parameter=amplitude,
+            mass_split=cosmo_cfg.get("mass_split", "normal"),
         )
         factory.cosmo = cosmo
         return factory, cosmo
@@ -145,6 +146,7 @@ def _create_ccl_factory(config):
         camb_extra_params=camb_extra,
         use_camb_hm_sampling=camb_baryon,
         amplitude_parameter=amplitude,
+        mass_split=cosmo_cfg.get("mass_split", "normal"),
     )
     factory.cosmo = cosmo
     return factory, cosmo


### PR DESCRIPTION
Augur's create_modeling_tools/_create_ccl_factory respects `mass_split` when building the standalone `cosmo = ccl.Cosmology(**cosmo_cfg)`, but it does not propagate `mass_split` into `CCLFactory(...)`.

Since Firecrown ModelingTools.prepare() creates a new cosmology through `self.ccl_factory.create(...)`, the cosmology actually used by ModelingTools falls back to `CCLFactory.mass_split` (default NORMAL) instead of the Augur config value.

To reproduce:
``` python
import copy

from augur.utils.firecrown_interface import create_modeling_tools
from firecrown.updatable import get_default_params_map
from pyccl.neutrinos import nu_masses

cfg = {
    "cosmo": {
        "Omega_c": 0.25,
        "Omega_b": 0.05,
        "h": 0.67,
        "n_s": 0.965,
        "sigma8": 0.81,
        "Neff": 3.046,
        "Omega_k": 0.0,
        "w0": -1.0,
        "wa": 0.0,
        "m_nu": 0.30,
        "mass_split": "equal",   # <- the setting we expect to survive
        "transfer_function": "boltzmann_camb",
    }
}

tools, cosmo_augur = create_modeling_tools(copy.deepcopy(cfg))

print("requested mass_split           =", cfg["cosmo"]["mass_split"])
print("augur direct cosmo mass_split  =", cosmo_augur.to_dict()["mass_split"])
print("factory mass_split             =", tools.ccl_factory.mass_split)

params = get_default_params_map(tools)

tools.update(params)
tools.prepare()

print("tools.ccl_cosmo mass_split     =", tools.ccl_cosmo.to_dict()["mass_split"])

print("expected masses for 'equal'    =", nu_masses(m_nu=cfg["cosmo"]["m_nu"], mass_split="equal"))
print(
    "masses used by ModelingTools   =",
    nu_masses(
        m_nu=cfg["cosmo"]["m_nu"],
        mass_split=tools.ccl_cosmo.to_dict()["mass_split"],
    ),
)
```

Before the fix:
```
requested mass_split           = equal
augur direct cosmo mass_split  = equal
factory mass_split             = NeutrinoMassSplits.NORMAL
tools.ccl_cosmo mass_split     = normal
expected masses for 'equal'    = [0.1 0.1 0.1]
masses used by ModelingTools   = [0.09569893 0.09609623 0.10820483]
```

After the fix:
```
requested mass_split           = equal
augur direct cosmo mass_split  = equal
factory mass_split             = NeutrinoMassSplits.EQUAL
tools.ccl_cosmo mass_split     = equal
expected masses for 'equal'    = [0.1 0.1 0.1]
masses used by ModelingTools   = [0.1 0.1 0.1]
```