### PR TITLE
Issue 140, 141 resolution

### DIFF
--- a/augur/analyze.py
+++ b/augur/analyze.py
@@ -63,105 +63,127 @@ class Analyze(object):
         else:
             # Load the ccl accuracy parameters if `generate` is not run
             if 'ccl_accuracy' in config.keys():
-                # Pass along spline control parameters
-                if 'spline_params' in config['ccl_accuracy'].keys():
-                    for key in config['ccl_accuracy']['spline_params'].keys():
-                        try:
-                            type_here = type(ccl.spline_params[key])
-                            value = config['ccl_accuracy']['spline_params'][key]
-                            ccl.spline_params[key] = type_here(value)
-                        except KeyError:
-                            logger.warning('The selected spline keyword `%s` is not recognized.',
-                                           key)
-                        except ValueError:
-                            logger.warning('The selected value `%s` could not be casted to `%s`.',
-                                           value, type_here)
-                # Pass along GSL control parameters
-                if 'gsl_params' in config['ccl_accuracy'].keys():
-                    for key in config['ccl_accuracy']['gsl_params'].keys():
-                        try:
-                            type_here = type(ccl.gsl_params[key])
-                            value = config['ccl_accuracy']['gsl_params'][key]
-                            ccl.gsl_params[key] = type_here(value)
-                        except KeyError:
-                            logger.warning('The selected GSL keyword `%s` is not recognized.', key)
-                        except ValueError:
-                            logger.warning('The selected value `%s` could not be casted to `%s`.',
-                                           value, type_here)
+                self._unpack_ccl_accuracy_parameters(config)
 
-        self.lk = likelihood  # Just to save some typing
-        self.tools = tools
-        self.req_params = req_params
+        self.lk, self.tools = likelihood, tools
+        self.req_params, self.norm_step = req_params, norm_step
         self.data_fid = self.lk.get_data_vector()
-        self.norm_step = norm_step
         # Get the fiducial cosmological parameters
         self.pars_fid = tools.get_ccl_cosmology().to_dict()
-        # need to potentially extract modified gravity parameters here
-        # and remove superfluous parameters
-        if 'mg_parametrization' in self.pars_fid.keys():
-            if self.pars_fid['mg_parametrization'] is not None:
-                warnings.warn("Modified gravity parametrizations are experimental and may not \
-                              be fully supported. Use with caution.")
-                mg = self.pars_fid.pop('mg_parametrization')
-                # mg is a MuSigmaMG object (from cosmo.to_dict()), not a raw dict
-                from pyccl.modified_gravity import MuSigmaMG
-                if isinstance(mg, MuSigmaMG):
-                    self.pars_fid['mg_musigma_mu'] = float(mg.mu_0)
-                    self.pars_fid['mg_musigma_sigma'] = float(mg.sigma_0)
-                    self.pars_fid['mg_musigma_c1'] = float(mg.c1_mg)
-                    self.pars_fid['mg_musigma_c2'] = float(mg.c2_mg)
-                    self.pars_fid['mg_musigma_lambda0'] = float(mg.lambda_mg)
-                elif isinstance(mg, dict):
-                    musigma = mg.get('mu_Sigma', None)
-                    if musigma is not None:
-                        self.pars_fid['mg_musigma_mu'] = float(musigma.get('mu_0', 0.0))
-                        self.pars_fid['mg_musigma_sigma'] = float(musigma.get('sigma_0', 0.0))
-                        self.pars_fid['mg_musigma_c1'] = float(musigma.get('c1_mg', 1.0))
-                        self.pars_fid['mg_musigma_c2'] = float(musigma.get('c2_mg', 1.0))
-                        self.pars_fid['mg_musigma_lambda0'] = float(musigma.get('lambda_mg', 0.0))
-        if 'baryonic_effects' in self.pars_fid.keys():
-            if self.pars_fid['baryonic_effects'] is not None:
-                warnings.warn("Baryonic effects parameters specified \
-                              but not currently implemented. Ignoring these parameters.")
-            self.pars_fid.pop('baryonic_effects')
-
         self.cf = tools.ccl_factory
 
         # Load the relevant section of the configuration file
         self.config = config['fisher']
 
         # Initialize pivot point
-        self.x = []
-        self.var_pars = None
-        self.derivatives = None
-        self.Fij = None
-        self.Fij_with_gprior = None
-        self.Fij_df = None
-        self.Fij_with_gprior_df = None
-        self.biased_cls, self.bi = None, None
-        self.par_bounds = []
-        self.norm = None
-        self.gpriors = []
-        self.gprior_pars = None
+        self.x, self.par_bounds, self.gpriors = [], [], []
+        self.var_pars = self.derivatives = self.gprior_pars = None
+        self.Fij = self.Fij_with_gprior = None
+        self.Fij_df = self.Fij_with_gprior_df = None
+        self.biased_cls = self.bi = self.J = None
+        self.norm = self.derivative_method = self.step_size = None
         self.transform_Omega_m, self.Om = False, None
         self.transform_S8, self.S8 = False, None
-        self.J = None
-        self.derivative_method = None
         self.derivative_args = {}
-        self.step_size = None
-        if 'transform_S8' in self.config.keys():
-            if type(self.config['transform_S8']) is not bool:
-                warnings.warn('transform_S8 not a boolean, therefore \
-                                not transforming Fisher to S8')
-            else:
-                self.transform_S8 = self.config['transform_S8']
-        if 'transform_Omega_m' in self.config.keys():
-            if type(self.config['transform_Omega_m']) is not bool:
-                warnings.warn('transform_Omega_m not a boolean, therefore \
-                                not transforming Fisher to Omega_m')
-            else:
-                self.transform_Omega_m = self.config['transform_Omega_m']
-        # Load the parameters to vary
+
+        if 'mg_parametrization' in self.pars_fid.keys():
+            self._unpack_mg_parameters()
+        if 'baryonic_effects' in self.pars_fid.keys():
+            self._unpack_baryonic_parameters()
+
+        self._unpack_transformations()
+        self._unpack_parameters_and_var_pars()
+        self._unpack_norm_step()
+        self._unpack_derivative_method()
+
+    def _unpack_transformations(self):
+        """
+        Unpack options to transform the Fisher matrix to different parameter bases.
+        Currently supported transformations are:
+        - Omega_c -> Omega_m
+        - sigma8 -> S8
+        """
+        transform_options = ['transform_S8', 'transform_Omega_m']
+        for option in transform_options:
+            if option in self.config.keys():
+                if type(self.config[option]) is not bool:
+                    warnings.warn(f'{option} not a boolean, therefore \
+                                    not transforming Fisher to {option.split("_")[1]}')
+                else:
+                    setattr(self, option, self.config[option])
+
+    def _unpack_gaussian_priors(self):
+        """
+        Unpack options to add Gaussian priors to the diagonal of the Fisher matrix.
+        """
+        # reads in associated gaussian prior width of parameters
+        if 'gaussian_priors' in self.config.keys():
+            self.gprior_pars = list(self.config['gaussian_priors'].keys())
+            for var in self.gprior_pars:
+                _val = self.config['gaussian_priors'][var]
+                self.gpriors.append(_val)
+
+    def _unpack_derivative_method(self):
+        """
+        Unpack options to compute numerical derivatives.
+        Currently supported methods are:
+        - 5pt_stencil
+        - numdifftools
+        - derivkit
+        """
+        # derivative method
+        self.derivative_method = self.config.get('derivative_method', '5pt_stencil')
+        self.derivative_args = self.config.get('derivative_args', {})
+        # step size
+        self.step_size = float(self.config.get('step', 0.01))
+
+    def _unpack_ccl_accuracy_parameters(self, config):
+        """
+        Unpack options to set the accuracy parameters of ccl
+        (called when user passes pre-made likelihood, tools, and req_params).
+        """
+        # Pass along spline control parameters
+        if 'spline_params' in config['ccl_accuracy'].keys():
+            for key in config['ccl_accuracy']['spline_params'].keys():
+                try:
+                    type_here = type(ccl.spline_params[key])
+                    value = config['ccl_accuracy']['spline_params'][key]
+                    ccl.spline_params[key] = type_here(value)
+                except KeyError:
+                    logger.warning('The selected spline keyword `%s` is not recognized.',
+                                   key)
+                except ValueError:
+                    logger.warning('The selected value `%s` could not be casted to `%s`.',
+                                   value, type_here)
+        # Pass along GSL control parameters
+        if 'gsl_params' in config['ccl_accuracy'].keys():
+            for key in config['ccl_accuracy']['gsl_params'].keys():
+                try:
+                    type_here = type(ccl.gsl_params[key])
+                    value = config['ccl_accuracy']['gsl_params'][key]
+                    ccl.gsl_params[key] = type_here(value)
+                except KeyError:
+                    logger.warning('The selected GSL keyword `%s` is not recognized.', key)
+                except ValueError:
+                    logger.warning('The selected value `%s` could not be casted to `%s`.',
+                                   value, type_here)
+
+    def _unpack_norm_step(self):
+        """
+        Unpack options to normalize the step size for numerical derivatives.
+        """
+        if (len(self.par_bounds) < 1) & (self.norm_step):
+            self.norm_step = False
+            warnings.warn('Parameter bounds not provided -- the step will not be normalized')
+        # Normalize the pivot point given the sampling region
+        if self.norm_step:
+            self.norm = np.array(self.par_bounds[:, 1]).astype(np.float64) - \
+                np.array(self.par_bounds[:, 0]).astype(np.float64)
+
+    def _unpack_parameters_and_var_pars(self):
+        """
+        Unpack options to load the parameters to vary.
+        """
         # We will allow 2 options -- one where we pass something
         # a la cosmosis with parameters and minimum, central, and max
         # we can also allow priors
@@ -195,25 +217,50 @@ class Analyze(object):
         # Cast to numpy array (this will be done later anyway)
         self.x = np.array(self.x).astype(np.float64)
         self.par_bounds = np.array(self.par_bounds)
-        if (len(self.par_bounds) < 1) & (self.norm_step):
-            self.norm_step = False
-            warnings.warn('Parameter bounds not provided -- the step will not be normalized')
-        # Normalize the pivot point given the sampling region
-        if self.norm_step:
-            self.norm = np.array(self.par_bounds[:, 1]).astype(np.float64) - \
-                np.array(self.par_bounds[:, 0]).astype(np.float64)
 
-        # reads in associated gaussian prior width of parameters
-        if 'gaussian_priors' in self.config.keys():
-            self.gprior_pars = list(self.config['gaussian_priors'].keys())
-            for var in self.gprior_pars:
-                _val = self.config['gaussian_priors'][var]
-                self.gpriors.append(_val)
-        # derivative method
-        self.derivative_method = self.config.get('derivative_method', '5pt_stencil')
-        self.derivative_args = self.config.get('derivative_args', {})
-        # step size
-        self.step_size = float(self.config.get('step', 0.01))
+    def _unpack_mg_parameters(self):
+        """
+        Unpack options to load modified gravity parameters from the fiducial cosmology
+        and add them to the dictionary of fiducial parameters.
+        Currently, only the MuSigma parametrization is supported,
+        and the expected parameters are:
+        - mg_musigma_mu
+        - mg_musigma_sigma
+        - mg_musigma_c1
+        - mg_musigma_c2
+        - mg_musigma_lambda0
+        """
+        if self.pars_fid['mg_parametrization'] is not None:
+            warnings.warn("Modified gravity parametrizations are experimental and may not \
+                            be fully supported. Use with caution.")
+            mg = self.pars_fid.pop('mg_parametrization')
+            # mg is a MuSigmaMG object (from cosmo.to_dict()), not a raw dict
+            from pyccl.modified_gravity import MuSigmaMG
+            if isinstance(mg, MuSigmaMG):
+                self.pars_fid['mg_musigma_mu'] = float(mg.mu_0)
+                self.pars_fid['mg_musigma_sigma'] = float(mg.sigma_0)
+                self.pars_fid['mg_musigma_c1'] = float(mg.c1_mg)
+                self.pars_fid['mg_musigma_c2'] = float(mg.c2_mg)
+                self.pars_fid['mg_musigma_lambda0'] = float(mg.lambda_mg)
+            elif isinstance(mg, dict):
+                musigma = mg.get('mu_Sigma', None)
+                if musigma is not None:
+                    self.pars_fid['mg_musigma_mu'] = float(musigma.get('mu_0', 0.0))
+                    self.pars_fid['mg_musigma_sigma'] = float(musigma.get('sigma_0', 0.0))
+                    self.pars_fid['mg_musigma_c1'] = float(musigma.get('c1_mg', 1.0))
+                    self.pars_fid['mg_musigma_c2'] = float(musigma.get('c2_mg', 1.0))
+                    self.pars_fid['mg_musigma_lambda0'] = float(musigma.get('lambda_mg', 0.0))
+
+    def _unpack_baryonic_parameters(self):
+        """
+        Unpack options to load baryonic parameters from the fiducial cosmology
+        and add them to the dictionary of fiducial parameters.
+        Currently, baryonic parameters are not implemented.
+        """
+        if self.pars_fid['baryonic_effects'] is not None:
+            warnings.warn("Baryonic effects parameters specified \
+                            but not currently implemented. Ignoring these parameters.")
+        self.pars_fid.pop('baryonic_effects')
 
     def get_Om(self):
         """
@@ -350,6 +397,8 @@ class Analyze(object):
 
         x : float, list or np.ndarray
             Point at which to compute the theory vector.
+            If 1D, it should have the same length as `labels`.
+            If 2D, it should be square with the same width and length as `labels`.
         labels : list
             Names of parameters to vary.
         pars_fid : dict
@@ -515,6 +564,10 @@ class Analyze(object):
         -----------
         save_txt : bool
             Save files of the Fisher + Gaussian prior matrix and Gaussian prior-only
+
+        Returns:
+        Fij_with_gprior : np.ndarray
+            Fisher matrix with Gaussian priors added in.
         """
 
         # 1) transformed parameters are specified (Omega_m or S8)

--- a/augur/analyze.py
+++ b/augur/analyze.py
@@ -93,6 +93,7 @@ class Analyze(object):
 
         self._unpack_transformations()
         self._unpack_parameters_and_var_pars()
+        self._unpack_gaussian_priors()
         self._unpack_norm_step()
         self._unpack_derivative_method()
 

--- a/augur/tests/test_analyze_helpers.py
+++ b/augur/tests/test_analyze_helpers.py
@@ -108,3 +108,298 @@ def test_add_gaussian_priors_preserves_width_order_with_unrecognized_entries():
     assert gprior_only.shape == (2, 2)
     assert gprior_only[0, 0] == pytest.approx(1.0 / 0.1**2)
     assert np.allclose(gprior_only[1], 0.0)
+
+
+# Tests for _unpack_transformations
+def test_unpack_transformations_transform_Omega_m_true():
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7}
+    extra_cfg = {'transform_Omega_m': True}
+    a = make_analyze(['Omega_c', 'Omega_b', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.transform_Omega_m is True
+    assert a.transform_S8 is False
+
+
+def test_unpack_transformations_transform_S8_true():
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7, 'sigma8': 0.8}
+    extra_cfg = {'transform_S8': True}
+    a = make_analyze(['Omega_c', 'Omega_b', 'h', 'sigma8'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.transform_S8 is True
+    assert a.transform_Omega_m is False
+
+
+def test_unpack_transformations_both_true():
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7, 'sigma8': 0.8}
+    extra_cfg = {'transform_Omega_m': True, 'transform_S8': True}
+    a = make_analyze(['Omega_c', 'Omega_b', 'h', 'sigma8'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.transform_Omega_m is True
+    assert a.transform_S8 is True
+
+
+def test_unpack_transformations_non_boolean_warns():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'transform_Omega_m': 'yes'}  # Not a boolean
+    with pytest.warns(UserWarning):
+        a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.transform_Omega_m is False
+
+
+def test_unpack_transformations_defaults_to_false():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    a = make_analyze(['Omega_c', 'h'], pars)
+    assert a.transform_Omega_m is False
+    assert a.transform_S8 is False
+
+
+# Tests for _unpack_gaussian_priors
+def test_unpack_gaussian_priors_single_prior():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    var_pars = ['Omega_c', 'h']
+    extra_cfg = {'gaussian_priors': {'Omega_c': 0.05}}
+    a = make_analyze(var_pars, pars, extra_fisher_cfg=extra_cfg)
+    # _unpack_gaussian_priors is called during __init__
+    assert a.gprior_pars == ['Omega_c']
+    assert 0.05 in a.gpriors
+    assert len(a.gpriors) == 1
+
+
+def test_unpack_gaussian_priors_multiple_priors():
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': 0.8}
+    var_pars = ['Omega_c', 'h', 'sigma8']
+    extra_cfg = {'gaussian_priors': {'Omega_c': 0.05, 'sigma8': 0.1}}
+    a = make_analyze(var_pars, pars, extra_fisher_cfg=extra_cfg)
+    # _unpack_gaussian_priors is called during __init__
+    assert set(a.gprior_pars) == {'Omega_c', 'sigma8'}
+    assert set(a.gpriors) == {0.05, 0.1}
+    assert len(a.gpriors) == 2
+
+
+def test_unpack_gaussian_priors_none_by_default():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    a = make_analyze(['Omega_c', 'h'], pars)
+    assert a.gprior_pars is None
+    assert len(a.gpriors) == 0
+
+
+def test_unpack_gaussian_priors_extracts_all_priors():
+    """Test that _unpack_gaussian_priors correctly extracts all gaussian prior widths"""
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'm_nu': 0.06}
+    var_pars = ['Omega_c', 'h', 'm_nu']
+    extra_cfg = {'gaussian_priors': {'Omega_c': 0.02, 'h': 0.05, 'm_nu': 0.01}}
+    a = make_analyze(var_pars, pars, extra_fisher_cfg=extra_cfg)
+    assert len(a.gprior_pars) == 3
+    assert set(a.gprior_pars) == {'Omega_c', 'h', 'm_nu'}
+    assert len(a.gpriors) == 3
+
+
+# Tests for _unpack_derivative_method
+def test_unpack_derivative_method_default():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    a = make_analyze(['Omega_c', 'h'], pars)
+    assert a.derivative_method == '5pt_stencil'
+    assert a.step_size == 0.01
+    assert a.derivative_args == {}
+
+
+def test_unpack_derivative_method_numdifftools():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'derivative_method': 'numdifftools', 'step': 0.005}
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.derivative_method == 'numdifftools'
+    assert a.step_size == 0.005
+
+
+def test_unpack_derivative_method_with_args():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {
+        'derivative_method': 'numdifftools',
+        'derivative_args': {'order': 4, 'full_output': True}
+    }
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.derivative_method == 'numdifftools'
+    assert a.derivative_args == {'order': 4, 'full_output': True}
+
+
+def test_unpack_derivative_method_derivkit():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'derivative_method': 'derivkit', 'step': 0.02}
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.derivative_method == 'derivkit'
+    assert a.step_size == 0.02
+
+
+# Tests for _unpack_norm_step
+def test_unpack_norm_step_true_with_bounds():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {
+        'var_pars': ['Omega_c', 'h'],
+        'parameters': {'Omega_c': [0.1, 0.2, 0.3], 'h': [0.6, 0.7, 0.8]}
+    }
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    # Now enable norm_step after initialization to trigger _unpack_norm_step behavior
+    # Reinitialize with norm_step=True
+    config = {'fisher': extra_cfg}
+    lk = DummyLikelihood()
+    tools = DummyTools(pars)
+    req_params = {}
+    a = Analyze(config, likelihood=lk, tools=tools, req_params=req_params, norm_step=True)
+    assert a.norm_step is True
+    expected_norm = np.array([0.3 - 0.1, 0.8 - 0.6])
+    assert np.allclose(a.norm, expected_norm)
+
+
+def test_unpack_norm_step_true_without_bounds_warns():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    config = {'fisher': extra_cfg}
+    lk = DummyLikelihood()
+    tools = DummyTools(pars)
+    req_params = {}
+    with pytest.warns(UserWarning):
+        a = Analyze(config, likelihood=lk, tools=tools, req_params=req_params, norm_step=True)
+    assert a.norm_step is False
+
+
+# Tests for _unpack_parameters_and_var_pars with 'parameters' option
+def test_unpack_parameters_with_bounds():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {
+        'parameters': {
+            'Omega_c': [0.1, 0.2, 0.3],
+            'h': [0.6, 0.7, 0.8]
+        }
+    }
+    a = make_analyze([], pars, extra_fisher_cfg=extra_cfg)
+    assert list(a.var_pars) == ['Omega_c', 'h']
+    assert np.allclose(a.x, [0.2, 0.7])
+    assert a.par_bounds.shape == (2, 2)
+    assert np.allclose(a.par_bounds[0], [0.1, 0.3])
+    assert np.allclose(a.par_bounds[1], [0.6, 0.8])
+
+
+def test_unpack_parameters_scalar_values():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {
+        'parameters': {
+            'Omega_c': 0.2,
+            'h': 0.7
+        }
+    }
+    a = make_analyze([], pars, extra_fisher_cfg=extra_cfg)
+    assert list(a.var_pars) == ['Omega_c', 'h']
+    assert np.allclose(a.x, [0.2, 0.7])
+    assert len(a.par_bounds) == 0
+
+
+def test_unpack_var_pars_from_fiducial():
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7}
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert list(a.var_pars) == ['Omega_c', 'h']
+    assert np.allclose(a.x, [0.2, 0.7])
+
+
+def test_unpack_var_pars_from_req_params():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'var_pars': ['Omega_c', 'test_param', 'h']}
+    config = {'fisher': extra_cfg}
+    lk = DummyLikelihood()
+    tools = DummyTools(pars)
+    req_params = {'test_param': 0.5}
+    a = Analyze(config, likelihood=lk, tools=tools, req_params=req_params)
+    assert list(a.var_pars) == ['Omega_c', 'test_param', 'h']
+    assert np.allclose(a.x, [0.2, 0.5, 0.7])
+
+
+def test_unpack_var_pars_unknown_parameter_raises():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'var_pars': ['Omega_c', 'unknown_param']}
+    config = {'fisher': extra_cfg}
+    lk = DummyLikelihood()
+    tools = DummyTools(pars)
+    req_params = {}
+    with pytest.raises(ValueError):
+        Analyze(config, likelihood=lk, tools=tools, req_params=req_params)
+
+
+def test_unpack_parameters_and_var_pars_precedence_warns():
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {
+        'parameters': {'Omega_c': 0.2},
+        'var_pars': ['h']
+    }
+    with pytest.warns(UserWarning):
+        a = make_analyze(['h'], pars, extra_fisher_cfg=extra_cfg)
+    # When both parameters and var_pars are present, parameters takes precedence
+    # and a warning is issued indicating var_pars is ignored
+    assert list(a.var_pars) == ['Omega_c']
+
+
+# Tests for _unpack_mg_parameters
+def test_unpack_mg_parameters_musigma_dict():
+    pars = {
+        'Omega_c': 0.2,
+        'h': 0.7,
+        'mg_parametrization': {
+            'mu_Sigma': {
+                'mu_0': 0.1,
+                'sigma_0': 0.2,
+                'c1_mg': 1.1,
+                'c2_mg': 1.2,
+                'lambda_mg': 0.5
+            }
+        }
+    }
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    with pytest.warns(UserWarning):  # MG is experimental
+        a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.pars_fid['mg_musigma_mu'] == 0.1
+    assert a.pars_fid['mg_musigma_sigma'] == 0.2
+    assert a.pars_fid['mg_musigma_c1'] == 1.1
+    assert a.pars_fid['mg_musigma_c2'] == 1.2
+    assert a.pars_fid['mg_musigma_lambda0'] == 0.5
+
+
+def test_unpack_mg_parameters_musigma_defaults():
+    pars = {
+        'Omega_c': 0.2,
+        'h': 0.7,
+        'mg_parametrization': {
+            'mu_Sigma': {}  # Empty dict should use defaults
+        }
+    }
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    with pytest.warns(UserWarning):
+        a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert a.pars_fid['mg_musigma_mu'] == 0.0
+    assert a.pars_fid['mg_musigma_sigma'] == 0.0
+    assert a.pars_fid['mg_musigma_c1'] == 1.0
+    assert a.pars_fid['mg_musigma_c2'] == 1.0
+    assert a.pars_fid['mg_musigma_lambda0'] == 0.0
+
+
+def test_unpack_mg_parameters_none():
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'mg_parametrization': None}
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    # When mg_parametrization is None, _unpack_mg_parameters doesn't do anything
+    # So mg_parametrization should still be in pars_fid as None
+    assert a.pars_fid['mg_parametrization'] is None
+
+
+# Tests for _unpack_baryonic_parameters
+def test_unpack_baryonic_parameters_warns():
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'baryonic_effects': {'baryon_model': 'some_model'}}
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    with pytest.warns(UserWarning):
+        a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    # baryonic_effects should be removed from pars_fid
+    assert 'baryonic_effects' not in a.pars_fid
+
+
+def test_unpack_baryonic_parameters_none():
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'baryonic_effects': None}
+    extra_cfg = {'var_pars': ['Omega_c', 'h']}
+    # When baryonic_effects is None, no warning is issued, it's just removed
+    a = make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    # baryonic_effects should be removed from pars_fid when it's None
+    assert 'baryonic_effects' not in a.pars_fid


### PR DESCRIPTION
Created to address refactoring concerns of the `Analyze` initialization in Issue #141 and add qualities of `x` into the docstrings (#140). #140 also specified the need to explicitly say that `Fij_with_gprior` is not returned, but it always is (current line 633), so we do not address this point. Tests were added to ensure the new private _unpack functions that were created in the `Analyze` initialization properly set the internal variables. 