### PR TITLE
Address Issues 139 and 61

### DIFF
--- a/augur/analyze.py
+++ b/augur/analyze.py
@@ -121,6 +121,15 @@ class Analyze(object):
         if 'gaussian_priors' in self.config.keys():
             self.gprior_pars = list(self.config['gaussian_priors'].keys())
             for var in self.gprior_pars:
+                in_var_pars = var in self.var_pars
+                is_transform_Omega_m = (var == 'Omega_m' and self.transform_Omega_m)
+                is_transform_S8 = (var == 'S8' and self.transform_S8)
+                if not (in_var_pars or is_transform_Omega_m or is_transform_S8):
+                    raise ValueError(
+                        f'Gaussian prior requested for `{var}`, but it is not in '
+                        f'var_pars and is not a recognised transform parameter. '
+                        f'Remove it from gaussian_priors or add it to var_pars.'
+                    )
                 _val = self.config['gaussian_priors'][var]
                 self.gpriors.append(_val)
 
@@ -195,6 +204,7 @@ class Analyze(object):
 
         if 'parameters' in self.config.keys():
             self.var_pars = list(self.config['parameters'].keys())
+            self._validate_amplitude_in_var_pars()
             for var in self.var_pars:
                 _val = self.config['parameters'][var]
                 if isinstance(_val, list):
@@ -207,6 +217,7 @@ class Analyze(object):
         # the fiducial values
         elif 'var_pars' in self.config.keys():
             self.var_pars = self.config['var_pars']
+            self._validate_amplitude_in_var_pars()
             for var in self.var_pars:
                 if var in self.pars_fid.keys():
                     self.x.append(self.pars_fid[var])
@@ -218,6 +229,38 @@ class Analyze(object):
         # Cast to numpy array (this will be done later anyway)
         self.x = np.array(self.x).astype(np.float64)
         self.par_bounds = np.array(self.par_bounds)
+
+    def _validate_amplitude_in_var_pars(self):
+        """
+        Check that the varied parameters are consistent with the fiducial
+        cosmology's amplitude parameter choice.
+
+        Raises ValueError if:
+        - Both sigma8 and A_s are in var_pars (mutually exclusive)
+        - sigma8 is in var_pars but A_s was used to build the fiducial cosmology
+          (sigma8 is None in pars_fid)
+        - A_s is in var_pars but sigma8 was used to build the fiducial cosmology
+          (A_s is None in pars_fid)
+        """
+        if 'sigma8' in self.var_pars and 'A_s' in self.var_pars:
+            raise ValueError(
+                'Both sigma8 and A_s are listed in var_pars. '
+                'These are mutually exclusive amplitude parameters; vary only one.'
+            )
+        if 'sigma8' in self.var_pars and self.pars_fid.get('sigma8') is None:
+            raise ValueError(
+                'sigma8 is listed in var_pars but the fiducial cosmology was '
+                'constructed with A_s as the amplitude parameter (sigma8 is None '
+                'in the fiducial). Remove sigma8 from var_pars or reconstruct '
+                'the fiducial cosmology using sigma8.'
+            )
+        if 'A_s' in self.var_pars and self.pars_fid.get('A_s') is None:
+            raise ValueError(
+                'A_s is listed in var_pars but the fiducial cosmology was '
+                'constructed with sigma8 as the amplitude parameter (A_s is None '
+                'in the fiducial). Remove A_s from var_pars or reconstruct '
+                'the fiducial cosmology using A_s.'
+            )
 
     def _unpack_mg_parameters(self):
         """

--- a/augur/generate.py
+++ b/augur/generate.py
@@ -24,7 +24,7 @@ from firecrown.parameters import ParamsMap
 from augur.utils.config_io import parse_config
 from augur.utils.firecrown_interface import create_modeling_tools, create_twopoint_filter
 import warnings
-from augur.utils.config_io import parse_array
+from augur.utils.config_io import parse_array, validate_amplitude_parameter
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +263,7 @@ def generate_sacc_and_stats(config):
                                         casted to `float`.', mu_sig[key], key)
 
             cosmo_cfg['mg_parametrization'] = ccl.modified_gravity.mu_Sigma.MuSigmaMG(**mu_sig)
+    validate_amplitude_parameter(cosmo_cfg)
     try:
         cosmo = ccl.Cosmology(**cosmo_cfg)
     except (KeyError, TypeError, ValueError) as e:

--- a/augur/tests/test_analyze_helpers.py
+++ b/augur/tests/test_analyze_helpers.py
@@ -96,18 +96,59 @@ def test_Jacobian_transform_entries():
     assert pytest.approx(J[ind_sigma8][ind_sigma8], rel=1e-8) == expected_s8_diag
 
 
-def test_add_gaussian_priors_preserves_width_order_with_unrecognized_entries():
+def test_add_gaussian_priors_preserves_width_order():
     pars = {'Omega_c': 0.2, 'h': 0.7}
     var_pars = ['Omega_c', 'h']
-    extra_cfg = {'gaussian_priors': {'unrecognized': 0.2, 'Omega_c': 0.1}}
+    extra_cfg = {'gaussian_priors': {'h': 0.2, 'Omega_c': 0.1}}
     a = make_analyze(var_pars, pars, extra_fisher_cfg=extra_cfg)
     a.Fij = np.zeros((len(var_pars), len(var_pars)))
 
     gprior_only = a.add_gaussian_priors(save_txt=False)
 
     assert gprior_only.shape == (2, 2)
-    assert gprior_only[0, 0] == pytest.approx(1.0 / 0.1**2)
-    assert np.allclose(gprior_only[1], 0.0)
+    ind_c = var_pars.index('Omega_c')
+    ind_h = var_pars.index('h')
+    assert gprior_only[ind_c, ind_c] == pytest.approx(1.0 / 0.1**2)
+    assert gprior_only[ind_h, ind_h] == pytest.approx(1.0 / 0.2**2)
+
+
+def test_unpack_gaussian_priors_nonexistent_parameter_raises():
+    # A prior on a parameter not in var_pars should raise at init time
+    pars = {'Omega_c': 0.2, 'h': 0.7}
+    extra_cfg = {'gaussian_priors': {'Omega_b': 0.05}}
+    with pytest.raises(ValueError, match='not in var_pars'):
+        make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
+
+
+def test_unpack_gaussian_priors_transform_Omega_m_allowed():
+    # A prior on Omega_m is valid when transform_Omega_m is active,
+    # even though Omega_m is not literally in var_pars
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7}
+    extra_cfg = {
+        'transform_Omega_m': True,
+        'gaussian_priors': {'Omega_m': 0.01},
+    }
+    a = make_analyze(['Omega_c', 'Omega_b', 'h'], pars, extra_fisher_cfg=extra_cfg)
+    assert 'Omega_m' in a.gprior_pars
+
+
+def test_unpack_gaussian_priors_transform_S8_allowed():
+    # A prior on S8 is valid when transform_S8 is active
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7, 'sigma8': 0.8}
+    extra_cfg = {
+        'transform_S8': True,
+        'gaussian_priors': {'S8': 0.02},
+    }
+    a = make_analyze(['Omega_c', 'h', 'sigma8'], pars, extra_fisher_cfg=extra_cfg)
+    assert 'S8' in a.gprior_pars
+
+
+def test_unpack_gaussian_priors_Omega_m_without_transform_raises():
+    # Omega_m prior without transform_Omega_m active should raise
+    pars = {'Omega_c': 0.2, 'Omega_b': 0.05, 'h': 0.7}
+    extra_cfg = {'gaussian_priors': {'Omega_m': 0.01}}
+    with pytest.raises(ValueError, match='not in var_pars'):
+        make_analyze(['Omega_c', 'h'], pars, extra_fisher_cfg=extra_cfg)
 
 
 # Tests for _unpack_transformations
@@ -332,6 +373,58 @@ def test_unpack_parameters_and_var_pars_precedence_warns():
     # When both parameters and var_pars are present, parameters takes precedence
     # and a warning is issued indicating var_pars is ignored
     assert list(a.var_pars) == ['Omega_c']
+
+
+# Tests for _validate_amplitude_in_var_pars
+def test_validate_amplitude_sigma8_active_and_varied():
+    # sigma8 is the active amplitude (non-None), can be varied
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': 0.8, 'A_s': None}
+    a = make_analyze(['Omega_c', 'sigma8'], pars)  # Should not raise
+    assert 'sigma8' in list(a.var_pars)
+
+
+def test_validate_amplitude_As_active_and_varied():
+    # A_s is the active amplitude (non-None), can be varied
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': None, 'A_s': 2.1e-9}
+    a = make_analyze(['Omega_c', 'A_s'], pars)  # Should not raise
+    assert 'A_s' in list(a.var_pars)
+
+
+def test_validate_amplitude_both_in_var_pars_raises():
+    # Both sigma8 and A_s in var_pars is always wrong
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': 0.8, 'A_s': 2.1e-9}
+    with pytest.raises(ValueError, match='mutually exclusive'):
+        make_analyze(['Omega_c', 'sigma8', 'A_s'], pars)
+
+
+def test_validate_amplitude_sigma8_varied_but_inactive_raises():
+    # sigma8 is in var_pars but fiducial was built with A_s (sigma8 is None)
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': None, 'A_s': 2.1e-9}
+    with pytest.raises(ValueError, match='sigma8.*A_s|A_s.*sigma8'):
+        make_analyze(['Omega_c', 'sigma8'], pars)
+
+
+def test_validate_amplitude_As_varied_but_inactive_raises():
+    # A_s is in var_pars but fiducial was built with sigma8 (A_s is None)
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': 0.8, 'A_s': None}
+    with pytest.raises(ValueError, match='A_s.*sigma8|sigma8.*A_s'):
+        make_analyze(['Omega_c', 'A_s'], pars)
+
+
+def test_validate_amplitude_in_var_pars_via_parameters_key_both_raises():
+    # Same check applies when using the 'parameters' config key
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': 0.8, 'A_s': None}
+    extra_cfg = {'parameters': {'sigma8': 0.8, 'A_s': 2.1e-9, 'Omega_c': 0.2}}
+    with pytest.raises(ValueError, match='mutually exclusive'):
+        make_analyze([], pars, extra_fisher_cfg=extra_cfg)
+
+
+def test_validate_amplitude_in_var_pars_via_parameters_key_As_inactive_raises():
+    # Using 'parameters' path: A_s is None in fiducial, cannot vary it
+    pars = {'Omega_c': 0.2, 'h': 0.7, 'sigma8': 0.8, 'A_s': None}
+    extra_cfg = {'parameters': {'A_s': 2.1e-9, 'Omega_c': 0.2}}
+    with pytest.raises(ValueError, match='A_s'):
+        make_analyze([], pars, extra_fisher_cfg=extra_cfg)
 
 
 # Tests for _unpack_mg_parameters

--- a/augur/tests/test_config_io.py
+++ b/augur/tests/test_config_io.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from augur.utils.config_io import parse_config, read_fisher_from_file
+from augur.utils.config_io import parse_config, read_fisher_from_file, validate_amplitude_parameter
 
 
 class TestParseConfig:
@@ -217,6 +217,49 @@ class TestReadFisherFromFile:
         assert fisher_read[0, 0] == pytest.approx(1.5)
         assert fisher_read[1, 2] == pytest.approx(0.3)
         assert fisher_read[2, 1] == pytest.approx(0.3)
+
+
+class TestValidateAmplitudeParameter:
+    """Tests for the validate_amplitude_parameter function."""
+
+    def test_sigma8_only_passes(self):
+        cosmo_cfg = {'Omega_c': 0.27, 'sigma8': 0.8, 'A_s': None}
+        validate_amplitude_parameter(cosmo_cfg)  # Should not raise
+
+    def test_A_s_only_passes(self):
+        cosmo_cfg = {'Omega_c': 0.27, 'sigma8': None, 'A_s': 2.1e-9}
+        validate_amplitude_parameter(cosmo_cfg)  # Should not raise
+
+    def test_neither_defined_raises(self):
+        cosmo_cfg = {'Omega_c': 0.27}
+        with pytest.raises(ValueError, match='Neither sigma8 nor A_s'):
+            validate_amplitude_parameter(cosmo_cfg)
+
+    def test_both_defined_raises(self):
+        cosmo_cfg = {'Omega_c': 0.27, 'sigma8': 0.8, 'A_s': 2.1e-9}
+        with pytest.raises(ValueError, match='mutually exclusive'):
+            validate_amplitude_parameter(cosmo_cfg)
+
+    def test_error_message_mentions_both_parameters(self):
+        cosmo_cfg = {'sigma8': 0.831, 'A_s': 2.1e-9}
+        with pytest.raises(ValueError, match='sigma8') as exc_info:
+            validate_amplitude_parameter(cosmo_cfg)
+        assert 'A_s' in str(exc_info.value)
+
+    def test_sigma8_none_A_s_defined_passes(self):
+        # Explicit None for sigma8 is treated as not defined
+        cosmo_cfg = {'sigma8': None, 'A_s': 2.1e-9}
+        validate_amplitude_parameter(cosmo_cfg)  # Should not raise
+
+    def test_A_s_none_sigma8_defined_passes(self):
+        # Explicit None for A_s is treated as not defined
+        cosmo_cfg = {'sigma8': 0.8, 'A_s': None}
+        validate_amplitude_parameter(cosmo_cfg)  # Should not raise
+
+    def test_both_none_raises(self):
+        cosmo_cfg = {'sigma8': None, 'A_s': None}
+        with pytest.raises(ValueError, match='Neither sigma8 nor A_s'):
+            validate_amplitude_parameter(cosmo_cfg)
 
     def test_read_fisher_return_order(self, tmp_path):
         """Test that read_fisher_from_file returns (fisher, fiducials) in correct order"""

--- a/augur/utils/config_io.py
+++ b/augur/utils/config_io.py
@@ -53,6 +53,27 @@ def parse_array(value):
     return np.asarray(result)
 
 
+def validate_amplitude_parameter(cosmo_cfg):
+    """
+    Validate that exactly one of sigma8 or A_s is specified in the cosmology config.
+    Raises ValueError if both are defined as non-None values, which is ambiguous.
+    """
+    has_sigma8 = cosmo_cfg.get('sigma8') is not None
+    has_A_s = cosmo_cfg.get('A_s') is not None
+    if has_sigma8 and has_A_s:
+        raise ValueError(
+            'Both sigma8 and A_s are specified in the cosmo config. '
+            'These parameters are mutually exclusive: use sigma8 (RMS matter '
+            'fluctuation in 8 h^-1 Mpc spheres) OR A_s (scalar amplitude of '
+            'the primordial power spectrum), not both.'
+        )
+    if not has_sigma8 and not has_A_s:
+        raise ValueError(
+            'Neither sigma8 nor A_s is specified in the cosmo config. '
+            'Exactly one amplitude parameter must be provided.'
+        )
+
+
 def parse_config(config):
     """
     Utility to parse configuration file

--- a/augur/utils/firecrown_interface.py
+++ b/augur/utils/firecrown_interface.py
@@ -19,6 +19,8 @@ from firecrown.data_functions import TwoPointBinFilterCollection, TwoPointBinFil
 from copy import deepcopy
 import warnings
 
+from augur.utils.config_io import validate_amplitude_parameter
+
 TRANSFER_FUNCTION_REGISTRY = {
     "boltzmann_camb": CCLPureModeTransferFunction.BOLTZMANN_CAMB,
     "boltzmann_class": CCLPureModeTransferFunction.BOLTZMANN_CLASS,
@@ -87,6 +89,7 @@ def _create_ccl_factory(config):
                                      halofit_version must be specified \
                                      in extra_parameters.camb.')
 
+    validate_amplitude_parameter(cosmo_cfg)
     amplitude = None
     if cosmo_cfg.get("A_s", None) is not None:
         amplitude = PoweSpecAmplitudeParameter.AS


### PR DESCRIPTION
- Added tests to analyze the consistency of amplitude parameters (A_s or sigma8) in various parts of the code. 
- Added tests to more explicitly raise errors if a Gaussian prior is applied to a non-existent variable (or transformed parameters).